### PR TITLE
Continue getting partially-downloaded file

### DIFF
--- a/cyberdrop-downloader.sh
+++ b/cyberdrop-downloader.sh
@@ -40,7 +40,7 @@ elif [ "$1" == "-m" ]; then
         mkdir "$ALBUM_NAME ($ALBUM_ID)" && cd "$ALBUM_NAME ($ALBUM_ID)";
 
         curl "$LINE" | grep 'id="file"' | cut -d '"' -f6 > LINKS;
-        wget -i LINKS -q --show-progress;
+        wget -i LINKS -q --show-progress -c;
         rm LINKS;
         cd "..";
     done < $FILENAME;
@@ -53,7 +53,7 @@ else
     mkdir "$ALBUM_NAME ($ALBUM_ID)" && cd "$ALBUM_NAME ($ALBUM_ID)";
 
     curl "$1" | grep 'id="file"' | cut -d '"' -f6 > LINKS;
-    wget -i LINKS -q --show-progress;
+    wget -i LINKS -q --show-progress -c;
     rm LINKS;
     cd "..";
 fi


### PR DESCRIPTION
`wget -c`
Skips already downloaded file(s) and continues partially-downloaded ones rather than downloading everything again.