### PR TITLE
Change dir

### DIFF
--- a/cyberdrop-downloader.sh
+++ b/cyberdrop-downloader.sh
@@ -37,7 +37,8 @@ elif [ "$1" == "-m" ]; then
     while read LINE; do
         ALBUM_NAME=$(curl "$LINE" | grep 'title has-text-centered' | cut -d '"' -f6 | head -n1 | sed 's/\//-/g');
         ALBUM_ID=$(basename "$LINE" | cut -d? -f1);
-        mkdir "$ALBUM_NAME ($ALBUM_ID)" && cd "$ALBUM_NAME ($ALBUM_ID)";
+        mkdir "$ALBUM_NAME ($ALBUM_ID)";
+        cd "$ALBUM_NAME ($ALBUM_ID)";
 
         curl "$LINE" | grep 'id="file"' | cut -d '"' -f6 > LINKS;
         wget -i LINKS -q --show-progress -c;
@@ -50,7 +51,8 @@ else
 
     ALBUM_NAME=$(curl "$1" | grep 'title has-text-centered' | cut -d '"' -f6 | head -n1 | sed 's/\//-/g');
     ALBUM_ID=$(basename "$1" | cut -d? -f1);
-    mkdir "$ALBUM_NAME ($ALBUM_ID)" && cd "$ALBUM_NAME ($ALBUM_ID)";
+    mkdir "$ALBUM_NAME ($ALBUM_ID)";
+    cd "$ALBUM_NAME ($ALBUM_ID)";
 
     curl "$1" | grep 'id="file"' | cut -d '"' -f6 > LINKS;
     wget -i LINKS -q --show-progress -c;

--- a/cyberdrop-downloader.sh
+++ b/cyberdrop-downloader.sh
@@ -37,8 +37,8 @@ elif [ "$1" == "-m" ]; then
     while read LINE; do
         ALBUM_NAME=$(curl "$LINE" | grep 'title has-text-centered' | cut -d '"' -f6 | head -n1 | sed 's/\//-/g');
         ALBUM_ID=$(basename "$LINE" | cut -d? -f1);
-        mkdir "$ALBUM_NAME ($ALBUM_ID)";
-        cd "$ALBUM_NAME ($ALBUM_ID)";
+        if [[ ! -d "$DIRECTORY" ]] && mkdir "$ALBUM_NAME ($ALBUM_ID)";
+        cd "$ALBUM_NAME ($ALBUM_ID)" || { echo "Could not change directory to: $ALBUM_NAME ($ALBUM_ID)"; exit 1; };
 
         curl "$LINE" | grep 'id="file"' | cut -d '"' -f6 > LINKS;
         wget -i LINKS -q --show-progress -c;
@@ -51,8 +51,8 @@ else
 
     ALBUM_NAME=$(curl "$1" | grep 'title has-text-centered' | cut -d '"' -f6 | head -n1 | sed 's/\//-/g');
     ALBUM_ID=$(basename "$1" | cut -d? -f1);
-    mkdir "$ALBUM_NAME ($ALBUM_ID)";
-    cd "$ALBUM_NAME ($ALBUM_ID)";
+    if [[ ! -d "$DIRECTORY" ]] && mkdir "$ALBUM_NAME ($ALBUM_ID)";
+    cd "$ALBUM_NAME ($ALBUM_ID)" || { echo "Could not change directory to: $ALBUM_NAME ($ALBUM_ID)"; exit 1; };
 
     curl "$1" | grep 'id="file"' | cut -d '"' -f6 > LINKS;
     wget -i LINKS -q --show-progress -c;

--- a/cyberdrop-downloader.sh
+++ b/cyberdrop-downloader.sh
@@ -37,7 +37,7 @@ elif [ "$1" == "-m" ]; then
     while read LINE; do
         ALBUM_NAME=$(curl "$LINE" | grep 'title has-text-centered' | cut -d '"' -f6 | head -n1 | sed 's/\//-/g');
         ALBUM_ID=$(basename "$LINE" | cut -d? -f1);
-        if [[ ! -d "$DIRECTORY" ]] && mkdir "$ALBUM_NAME ($ALBUM_ID)";
+        if [[ ! -d "$ALBUM_NAME ($ALBUM_ID)" ]] && mkdir "$ALBUM_NAME ($ALBUM_ID)";
         cd "$ALBUM_NAME ($ALBUM_ID)" || { echo "Could not change directory to: $ALBUM_NAME ($ALBUM_ID)"; exit 1; };
 
         curl "$LINE" | grep 'id="file"' | cut -d '"' -f6 > LINKS;
@@ -51,7 +51,7 @@ else
 
     ALBUM_NAME=$(curl "$1" | grep 'title has-text-centered' | cut -d '"' -f6 | head -n1 | sed 's/\//-/g');
     ALBUM_ID=$(basename "$1" | cut -d? -f1);
-    if [[ ! -d "$DIRECTORY" ]] && mkdir "$ALBUM_NAME ($ALBUM_ID)";
+    if [[ ! -d "$ALBUM_NAME ($ALBUM_ID)" ]] && mkdir "$ALBUM_NAME ($ALBUM_ID)";
     cd "$ALBUM_NAME ($ALBUM_ID)" || { echo "Could not change directory to: $ALBUM_NAME ($ALBUM_ID)"; exit 1; };
 
     curl "$1" | grep 'id="file"' | cut -d '"' -f6 > LINKS;


### PR DESCRIPTION
Change dir fails if the directory already exists.

This fixes it and the `cd` is made even if the mkdir fails because the folder already exists.